### PR TITLE
Add MinIO service and tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "mongomock>=4.3.0",
+    "minio>=7.2.7",
     "pydantic>=2.11.9",
     "pytest>=8.4.2",
     "pytest-mock>=3.15.1",

--- a/src/services/minio/__init__.py
+++ b/src/services/minio/__init__.py
@@ -1,0 +1,6 @@
+"""MinIO service package providing high-level object storage utilities."""
+
+from .minio_service import MinioService
+from .minio_models import MinioConfig
+
+__all__ = ["MinioService", "MinioConfig"]

--- a/src/services/minio/minio_models.py
+++ b/src/services/minio/minio_models.py
@@ -1,0 +1,131 @@
+"""MinIO configuration models for object storage connections."""
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator
+
+# Bucket naming constraints (matching AWS S3/MinIO rules)
+MIN_BUCKET_NAME_LENGTH = 3
+MAX_BUCKET_NAME_LENGTH = 63
+ALLOWED_BUCKET_CHARS = set("abcdefghijklmnopqrstuvwxyz0123456789-.")
+
+# Error messages
+ERROR_EMPTY_ENDPOINT = "Endpoint cannot be empty"
+ERROR_EMPTY_ACCESS_KEY = "Access key cannot be empty"
+ERROR_EMPTY_SECRET_KEY = "Secret key cannot be empty"
+ERROR_INVALID_BUCKET_LENGTH = (
+    f"Bucket name must be between {MIN_BUCKET_NAME_LENGTH} and "
+    f"{MAX_BUCKET_NAME_LENGTH} characters long"
+)
+ERROR_BUCKET_INVALID_CHARS = (
+    "Bucket name may only contain lowercase letters, numbers, '.' and '-'"
+)
+ERROR_BUCKET_START_END = (
+    "Bucket name must start and end with a lowercase letter or number"
+)
+
+
+class MinioConfig(BaseModel):
+    """Configuration model describing how to connect to a MinIO deployment."""
+
+    endpoint: str = Field(
+        ...,
+        description="Hostname (and optional port) for the MinIO server",
+        examples=["play.min.io", "minio.internal:9000"],
+    )
+    access_key: str = Field(
+        ...,
+        description="Access key used for authentication",
+        examples=["Q3AM3UQ867SPQQA43P2F"],
+    )
+    secret_key: str = Field(
+        ...,
+        description="Secret key used for authentication",
+        examples=["zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG"],
+    )
+    secure: bool = Field(
+        default=True,
+        description="Whether to use HTTPS when communicating with the server",
+    )
+    region: str | None = Field(
+        default=None,
+        description="Optional region name used when creating buckets",
+    )
+    session_token: str | None = Field(
+        default=None,
+        description="Optional session token for temporary credentials",
+    )
+    default_bucket: str | None = Field(
+        default=None,
+        description="Default bucket name used for storage operations",
+        examples=["application-data"],
+    )
+    auto_create_bucket: bool = Field(
+        default=False,
+        description="Create the default bucket automatically when initializing the service",
+    )
+
+    @field_validator("endpoint")
+    @classmethod
+    def validate_endpoint(cls, value: str) -> str:
+        """Ensure the endpoint value is not empty."""
+        if not value or not value.strip():
+            raise ValueError(ERROR_EMPTY_ENDPOINT)
+        return value
+
+    @field_validator("access_key")
+    @classmethod
+    def validate_access_key(cls, value: str) -> str:
+        """Ensure the access key is provided."""
+        if not value or not value.strip():
+            raise ValueError(ERROR_EMPTY_ACCESS_KEY)
+        return value
+
+    @field_validator("secret_key")
+    @classmethod
+    def validate_secret_key(cls, value: str) -> str:
+        """Ensure the secret key is provided."""
+        if not value or not value.strip():
+            raise ValueError(ERROR_EMPTY_SECRET_KEY)
+        return value
+
+    @field_validator("default_bucket")
+    @classmethod
+    def validate_default_bucket(
+        cls, value: str | None, info: ValidationInfo
+    ) -> str | None:
+        """Validate bucket naming rules when a default bucket is provided."""
+        if value is None:
+            return None
+
+        bucket = value.strip()
+        length = len(bucket)
+        if length < MIN_BUCKET_NAME_LENGTH or length > MAX_BUCKET_NAME_LENGTH:
+            raise ValueError(ERROR_INVALID_BUCKET_LENGTH)
+
+        if not set(bucket).issubset(ALLOWED_BUCKET_CHARS):
+            raise ValueError(ERROR_BUCKET_INVALID_CHARS)
+
+        if bucket[0] not in ALLOWED_BUCKET_CHARS - {"-", "."} or bucket[-1] not in (
+            ALLOWED_BUCKET_CHARS - {"-", "."}
+        ):
+            raise ValueError(ERROR_BUCKET_START_END)
+
+        if ".." in bucket or ".-" in bucket or "-." in bucket:
+            raise ValueError(ERROR_BUCKET_INVALID_CHARS)
+
+        # Store the normalized bucket name back into the data to avoid repeated stripping
+        info.data.setdefault("default_bucket", bucket)
+        return bucket
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "endpoint": "play.min.io:9000",
+                "access_key": "minio",
+                "secret_key": "minio123",
+                "secure": False,
+                "region": "us-east-1",
+                "default_bucket": "application-data",
+                "auto_create_bucket": True,
+            },
+        }
+    )

--- a/src/services/minio/minio_service.py
+++ b/src/services/minio/minio_service.py
@@ -1,0 +1,308 @@
+"""Simplified MinIO service for object storage operations."""
+
+from __future__ import annotations
+
+import io
+import logging
+from datetime import timedelta
+from typing import Any
+
+from minio import Minio
+from minio.error import S3Error
+
+from .minio_models import MinioConfig
+
+# Error messages
+ERROR_BUCKET_REQUIRED = "Bucket name must be provided when no default bucket is configured"
+
+
+class MinioService:
+    """High-level wrapper around the official MinIO Python client."""
+
+    def __init__(self, logger: logging.Logger, config: MinioConfig) -> None:
+        """Create a new MinioService instance."""
+        self.log = logger
+        self.config = config
+
+        self.log.info("Initializing MinIO client for endpoint: %s", config.endpoint)
+
+        try:
+            self._client = Minio(
+                config.endpoint,
+                access_key=config.access_key,
+                secret_key=config.secret_key,
+                session_token=config.session_token,
+                secure=config.secure,
+                region=config.region,
+            )
+
+            if config.default_bucket:
+                if config.auto_create_bucket:
+                    self.ensure_bucket(config.default_bucket)
+                else:
+                    self.log.debug("Using configured default bucket: %s", config.default_bucket)
+
+        except Exception:
+            self.log.exception("Failed to initialize MinIO client")
+            raise
+
+    @property
+    def client(self) -> Minio:
+        """Expose the underlying MinIO client for advanced operations."""
+        return self._client
+
+    # ------------------------------------------------------------------
+    # Helper utilities
+    # ------------------------------------------------------------------
+    def _resolve_bucket(self, bucket_name: str | None) -> str:
+        """Resolve a bucket name using the configured default when necessary."""
+        if bucket_name:
+            return bucket_name
+        if self.config.default_bucket:
+            return self.config.default_bucket
+        raise ValueError(ERROR_BUCKET_REQUIRED)
+
+    # ------------------------------------------------------------------
+    # Health checks and bucket operations
+    # ------------------------------------------------------------------
+    def health_check(self) -> list[str]:
+        """Return the list of accessible buckets, verifying connectivity."""
+        try:
+            buckets = self._client.list_buckets()
+            bucket_names = [bucket.name for bucket in buckets]
+            self.log.debug("Successfully listed %d bucket(s)", len(bucket_names))
+            return bucket_names
+        except S3Error:
+            self.log.exception("MinIO health check failed")
+            raise
+
+    def bucket_exists(self, bucket_name: str) -> bool:
+        """Check whether a bucket exists."""
+        self.log.debug("Checking if bucket exists: %s", bucket_name)
+        exists = self._client.bucket_exists(bucket_name)
+        self.log.info("Bucket %s exists: %s", bucket_name, exists)
+        return exists
+
+    def ensure_bucket(self, bucket_name: str) -> None:
+        """Ensure the provided bucket exists, creating it when necessary."""
+        if self.bucket_exists(bucket_name):
+            return
+
+        self.log.info("Creating bucket: %s", bucket_name)
+        self._client.make_bucket(bucket_name, location=self.config.region)
+        self.log.info("Bucket created successfully: %s", bucket_name)
+
+    def list_buckets(self) -> list[str]:
+        """List all buckets available to the credentials."""
+        self.log.debug("Listing buckets")
+        buckets = self._client.list_buckets()
+        bucket_names = [bucket.name for bucket in buckets]
+        self.log.info("Found %d bucket(s)", len(bucket_names))
+        return bucket_names
+
+    # ------------------------------------------------------------------
+    # Object operations
+    # ------------------------------------------------------------------
+    def upload_file(
+        self,
+        object_name: str,
+        file_path: str,
+        *,
+        bucket_name: str | None = None,
+        content_type: str | None = None,
+        metadata: dict[str, str] | None = None,
+    ) -> str:
+        """Upload a file from disk to the specified bucket."""
+        resolved_bucket = self._resolve_bucket(bucket_name)
+        self.log.debug(
+            "Uploading file '%s' to bucket '%s' as object '%s'", file_path, resolved_bucket, object_name
+        )
+        result = self._client.fput_object(
+            resolved_bucket,
+            object_name,
+            file_path,
+            content_type=content_type,
+            metadata=metadata,
+        )
+        self.log.info(
+            "Uploaded file '%s' to bucket '%s' (etag=%s)",
+            object_name,
+            resolved_bucket,
+            result.etag,
+        )
+        return result.object_name
+
+    def download_file(
+        self,
+        object_name: str,
+        file_path: str,
+        *,
+        bucket_name: str | None = None,
+    ) -> None:
+        """Download an object from MinIO and store it on disk."""
+        resolved_bucket = self._resolve_bucket(bucket_name)
+        self.log.debug(
+            "Downloading object '%s' from bucket '%s' to '%s'",
+            object_name,
+            resolved_bucket,
+            file_path,
+        )
+        self._client.fget_object(resolved_bucket, object_name, file_path)
+        self.log.info(
+            "Downloaded object '%s' from bucket '%s' to '%s'",
+            object_name,
+            resolved_bucket,
+            file_path,
+        )
+
+    def upload_data(
+        self,
+        object_name: str,
+        data: bytes,
+        *,
+        bucket_name: str | None = None,
+        content_type: str | None = None,
+        metadata: dict[str, str] | None = None,
+    ) -> str:
+        """Upload raw bytes to MinIO without touching the filesystem."""
+        resolved_bucket = self._resolve_bucket(bucket_name)
+        data_stream = io.BytesIO(data)
+        length = len(data)
+        self.log.debug(
+            "Uploading %d bytes to bucket '%s' as object '%s'",
+            length,
+            resolved_bucket,
+            object_name,
+        )
+        result = self._client.put_object(
+            resolved_bucket,
+            object_name,
+            data_stream,
+            length,
+            content_type=content_type,
+            metadata=metadata,
+        )
+        self.log.info(
+            "Uploaded %d bytes to bucket '%s' (etag=%s)",
+            length,
+            resolved_bucket,
+            result.etag,
+        )
+        return result.object_name
+
+    def download_data(
+        self,
+        object_name: str,
+        *,
+        bucket_name: str | None = None,
+    ) -> bytes:
+        """Download an object's contents directly into memory."""
+        resolved_bucket = self._resolve_bucket(bucket_name)
+        self.log.debug(
+            "Downloading object '%s' from bucket '%s' into memory",
+            object_name,
+            resolved_bucket,
+        )
+        response = self._client.get_object(resolved_bucket, object_name)
+        try:
+            data = response.read()
+            self.log.info(
+                "Downloaded object '%s' from bucket '%s' (%d bytes)",
+                object_name,
+                resolved_bucket,
+                len(data),
+            )
+            return data
+        finally:
+            response.close()
+            response.release_conn()
+
+    def list_objects(
+        self,
+        *,
+        bucket_name: str | None = None,
+        prefix: str | None = None,
+        recursive: bool = True,
+    ) -> list[str]:
+        """List objects in a bucket, returning their names."""
+        resolved_bucket = self._resolve_bucket(bucket_name)
+        self.log.debug(
+            "Listing objects in bucket '%s' (prefix=%s, recursive=%s)",
+            resolved_bucket,
+            prefix,
+            recursive,
+        )
+        objects = self._client.list_objects(resolved_bucket, prefix=prefix, recursive=recursive)
+        object_names = [obj.object_name for obj in objects]
+        self.log.info(
+            "Found %d object(s) in bucket '%s'",
+            len(object_names),
+            resolved_bucket,
+        )
+        return object_names
+
+    def remove_object(
+        self,
+        object_name: str,
+        *,
+        bucket_name: str | None = None,
+    ) -> None:
+        """Remove a single object from a bucket."""
+        resolved_bucket = self._resolve_bucket(bucket_name)
+        self.log.debug("Removing object '%s' from bucket '%s'", object_name, resolved_bucket)
+        self._client.remove_object(resolved_bucket, object_name)
+        self.log.info(
+            "Removed object '%s' from bucket '%s'",
+            object_name,
+            resolved_bucket,
+        )
+
+    def generate_presigned_url(
+        self,
+        object_name: str,
+        *,
+        bucket_name: str | None = None,
+        method: str = "GET",
+        expires: timedelta = timedelta(minutes=15),
+        response_headers: dict[str, str] | None = None,
+        request_params: dict[str, Any] | None = None,
+    ) -> str:
+        """Generate a presigned URL for accessing an object."""
+        resolved_bucket = self._resolve_bucket(bucket_name)
+        self.log.debug(
+            "Generating presigned URL for object '%s' (method=%s, expires=%s)",
+            object_name,
+            method,
+            expires,
+        )
+        url = self._client.get_presigned_url(
+            method,
+            resolved_bucket,
+            object_name,
+            expires=expires,
+            response_headers=response_headers,
+            request_params=request_params,
+        )
+        self.log.info("Generated presigned URL for object '%s'", object_name)
+        return url
+
+    def stat_object(
+        self,
+        object_name: str,
+        *,
+        bucket_name: str | None = None,
+    ) -> Any:
+        """Retrieve metadata about an object."""
+        resolved_bucket = self._resolve_bucket(bucket_name)
+        self.log.debug(
+            "Fetching metadata for object '%s' in bucket '%s'",
+            object_name,
+            resolved_bucket,
+        )
+        metadata = self._client.stat_object(resolved_bucket, object_name)
+        self.log.info(
+            "Fetched metadata for object '%s' in bucket '%s'",
+            object_name,
+            resolved_bucket,
+        )
+        return metadata

--- a/tests/minio/test_minio_service.py
+++ b/tests/minio/test_minio_service.py
@@ -1,0 +1,312 @@
+"""Test suite for the simplified MinIO service implementation."""
+
+import logging
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+from minio.error import S3Error
+
+from services.minio.minio_models import MinioConfig
+from services.minio.minio_service import ERROR_BUCKET_REQUIRED, MinioService
+
+# ruff: noqa: S101,SLF001,ARG001,ARG002,S106,FBT003,PLC0415
+
+
+@pytest.fixture
+def mock_logger() -> Mock:
+    """Return a mock logger for service tests."""
+    return Mock(spec=logging.Logger)
+
+
+@pytest.fixture
+def valid_config() -> MinioConfig:
+    """Provide a baseline Minio configuration for tests."""
+    return MinioConfig(
+        endpoint="play.min.io:9000",
+        access_key="test-access",
+        secret_key="test-secret",
+        secure=False,
+        region="us-east-1",
+        default_bucket="test-bucket",
+        auto_create_bucket=False,
+    )
+
+
+@pytest.fixture
+def service_with_client(
+    mock_logger: Mock, valid_config: MinioConfig
+) -> tuple[MinioService, Mock]:
+    """Create a MinioService instance with a mocked client."""
+    with patch("services.minio.minio_service.Minio") as minio_ctor:
+        client_instance = Mock()
+        minio_ctor.return_value = client_instance
+        service = MinioService(mock_logger, valid_config)
+        yield service, client_instance
+
+
+class TestInitialization:
+    """Verify service construction and configuration handling."""
+
+    def test_initializes_client_with_expected_arguments(
+        self, mock_logger: Mock, valid_config: MinioConfig
+    ) -> None:
+        """Ensure the MinIO client receives the correct parameters."""
+        with patch("services.minio.minio_service.Minio") as minio_ctor:
+            client_instance = Mock()
+            minio_ctor.return_value = client_instance
+
+            service = MinioService(mock_logger, valid_config)
+
+            minio_ctor.assert_called_once_with(
+                valid_config.endpoint,
+                access_key=valid_config.access_key,
+                secret_key=valid_config.secret_key,
+                session_token=valid_config.session_token,
+                secure=valid_config.secure,
+                region=valid_config.region,
+            )
+            assert service.config == valid_config
+            assert service.log is mock_logger
+
+    def test_auto_creates_bucket_when_configured(
+        self, mock_logger: Mock, valid_config: MinioConfig
+    ) -> None:
+        """Auto-creation should invoke bucket creation workflow."""
+        config = valid_config.model_copy(update={"auto_create_bucket": True})
+
+        with patch("services.minio.minio_service.Minio") as minio_ctor:
+            client_instance = Mock()
+            client_instance.bucket_exists.return_value = False
+            minio_ctor.return_value = client_instance
+
+            MinioService(mock_logger, config)
+
+            client_instance.bucket_exists.assert_called_once_with(config.default_bucket)
+            client_instance.make_bucket.assert_called_once_with(
+                config.default_bucket, location=config.region
+            )
+
+    def test_init_logs_and_re_raises_on_failure(
+        self, mock_logger: Mock, valid_config: MinioConfig
+    ) -> None:
+        """Errors during initialization should be logged and propagated."""
+        with patch(
+            "services.minio.minio_service.Minio",
+            side_effect=S3Error("code", "message", "request", "resource"),
+        ):
+            with pytest.raises(S3Error):
+                MinioService(mock_logger, valid_config)
+
+        mock_logger.exception.assert_called_once_with("Failed to initialize MinIO client")
+
+
+class TestHealthAndBuckets:
+    """Exercise health check and bucket utility methods."""
+
+    def test_health_check_success(
+        self, service_with_client: tuple[MinioService, Mock]
+    ) -> None:
+        """Health check should return bucket names on success."""
+        service, client = service_with_client
+        client.list_buckets.return_value = [
+            SimpleNamespace(name="alpha"),
+            SimpleNamespace(name="beta"),
+        ]
+
+        result = service.health_check()
+
+        assert result == ["alpha", "beta"]
+        client.list_buckets.assert_called_once_with()
+
+    def test_health_check_failure_logs_and_raises(
+        self, service_with_client: tuple[MinioService, Mock]
+    ) -> None:
+        """Propagate S3 errors from the health check."""
+        service, client = service_with_client
+        client.list_buckets.side_effect = S3Error("code", "message", "request", "resource")
+
+        with pytest.raises(S3Error):
+            service.health_check()
+
+        service.log.exception.assert_called_once_with("MinIO health check failed")
+
+    def test_bucket_exists_delegates_to_client(
+        self, service_with_client: tuple[MinioService, Mock]
+    ) -> None:
+        """bucket_exists should call the underlying client."""
+        service, client = service_with_client
+        client.bucket_exists.return_value = True
+
+        assert service.bucket_exists("sample") is True
+        client.bucket_exists.assert_called_once_with("sample")
+
+    def test_ensure_bucket_skips_when_present(
+        self, service_with_client: tuple[MinioService, Mock]
+    ) -> None:
+        """ensure_bucket should avoid creating existing buckets."""
+        service, client = service_with_client
+        client.bucket_exists.return_value = True
+
+        service.ensure_bucket("existing")
+
+        client.bucket_exists.assert_called_once_with("existing")
+        client.make_bucket.assert_not_called()
+
+    def test_ensure_bucket_creates_when_missing(
+        self, service_with_client: tuple[MinioService, Mock]
+    ) -> None:
+        """Missing buckets should be created."""
+        service, client = service_with_client
+        client.bucket_exists.return_value = False
+
+        service.ensure_bucket("new-bucket")
+
+        client.bucket_exists.assert_called_once_with("new-bucket")
+        client.make_bucket.assert_called_once_with("new-bucket", location=service.config.region)
+
+    def test_list_buckets_returns_names(
+        self, service_with_client: tuple[MinioService, Mock]
+    ) -> None:
+        """list_buckets should return plain bucket names."""
+        service, client = service_with_client
+        client.list_buckets.return_value = [SimpleNamespace(name="bucket-a")]
+
+        assert service.list_buckets() == ["bucket-a"]
+        client.list_buckets.assert_called_once_with()
+
+
+class TestObjectOperations:
+    """Validate object-level operations."""
+
+    def test_upload_file_uses_resolved_bucket(
+        self, service_with_client: tuple[MinioService, Mock]
+    ) -> None:
+        """Uploading files should return the object name."""
+        service, client = service_with_client
+        client.fput_object.return_value = SimpleNamespace(object_name="uploaded.txt", etag="etag")
+
+        result = service.upload_file(
+            object_name="uploaded.txt",
+            file_path="/tmp/file.txt",
+            bucket_name="custom-bucket",
+            content_type="text/plain",
+        )
+
+        assert result == "uploaded.txt"
+        client.fput_object.assert_called_once_with(
+            "custom-bucket",
+            "uploaded.txt",
+            "/tmp/file.txt",
+            content_type="text/plain",
+            metadata=None,
+        )
+
+    def test_download_file_invokes_client(
+        self, service_with_client: tuple[MinioService, Mock]
+    ) -> None:
+        """Downloading files should call fget_object."""
+        service, client = service_with_client
+
+        service.download_file("object.txt", "/tmp/output.txt")
+
+        client.fget_object.assert_called_once_with("test-bucket", "object.txt", "/tmp/output.txt")
+
+    def test_upload_data_returns_object_name(
+        self, service_with_client: tuple[MinioService, Mock]
+    ) -> None:
+        """Uploading byte payloads should delegate to put_object."""
+        service, client = service_with_client
+        client.put_object.return_value = SimpleNamespace(object_name="payload.bin", etag="etag")
+
+        result = service.upload_data("payload.bin", b"hello world")
+
+        assert result == "payload.bin"
+        args, kwargs = client.put_object.call_args
+        assert args[0] == "test-bucket"
+        assert args[1] == "payload.bin"
+        assert kwargs["content_type"] is None
+        assert kwargs["metadata"] is None
+
+    def test_download_data_closes_response(
+        self, service_with_client: tuple[MinioService, Mock]
+    ) -> None:
+        """download_data should clean up the response object."""
+        service, client = service_with_client
+        response = Mock()
+        response.read.return_value = b"payload"
+        client.get_object.return_value = response
+
+        result = service.download_data("payload.bin")
+
+        assert result == b"payload"
+        response.read.assert_called_once_with()
+        response.close.assert_called_once_with()
+        response.release_conn.assert_called_once_with()
+
+    def test_list_objects_returns_names(
+        self, service_with_client: tuple[MinioService, Mock]
+    ) -> None:
+        """list_objects should iterate over returned objects."""
+        service, client = service_with_client
+        client.list_objects.return_value = iter(
+            [SimpleNamespace(object_name="file-1"), SimpleNamespace(object_name="file-2")]
+        )
+
+        assert service.list_objects(prefix="", recursive=False) == ["file-1", "file-2"]
+        client.list_objects.assert_called_once_with("test-bucket", prefix="", recursive=False)
+
+    def test_remove_object_invokes_client(
+        self, service_with_client: tuple[MinioService, Mock]
+    ) -> None:
+        """remove_object should call the client with resolved bucket."""
+        service, client = service_with_client
+
+        service.remove_object("delete-me.txt")
+
+        client.remove_object.assert_called_once_with("test-bucket", "delete-me.txt")
+
+    def test_generate_presigned_url(
+        self, service_with_client: tuple[MinioService, Mock]
+    ) -> None:
+        """Presigned URLs should be generated via the client."""
+        service, client = service_with_client
+        client.get_presigned_url.return_value = "https://example.com/presigned"
+
+        url = service.generate_presigned_url(
+            "file.txt",
+            method="PUT",
+            expires=timedelta(minutes=5),
+            response_headers={"x-test": "true"},
+            request_params={"uploads": "1"},
+        )
+
+        assert url == "https://example.com/presigned"
+        client.get_presigned_url.assert_called_once()
+
+    def test_stat_object_returns_metadata(
+        self, service_with_client: tuple[MinioService, Mock]
+    ) -> None:
+        """stat_object should return the metadata returned by the client."""
+        service, client = service_with_client
+        metadata = SimpleNamespace(size=128)
+        client.stat_object.return_value = metadata
+
+        result = service.stat_object("file.txt", bucket_name="custom")
+
+        assert result is metadata
+        client.stat_object.assert_called_once_with("custom", "file.txt")
+
+    def test_operations_require_bucket_when_no_default(
+        self, mock_logger: Mock, valid_config: MinioConfig
+    ) -> None:
+        """Calling object operations without a bucket should raise when no default exists."""
+        config = valid_config.model_copy(update={"default_bucket": None})
+        with patch("services.minio.minio_service.Minio") as minio_ctor:
+            client_instance = Mock()
+            minio_ctor.return_value = client_instance
+            service = MinioService(mock_logger, config)
+
+        with pytest.raises(ValueError, match=ERROR_BUCKET_REQUIRED):
+            service.upload_file("object.txt", "/tmp/file.txt")


### PR DESCRIPTION
## Summary
- add a MinIO configuration model and service that mirror the MongoDB service patterns
- cover the new service with a comprehensive mocked test suite
- declare the MinIO dependency in the project metadata

## Testing
- pytest *(fails: missing third-party dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9fae1753c8320a10df5dc22f1fb2c